### PR TITLE
make Graph::transaction optional

### DIFF
--- a/zflow_graph/src/types.rs
+++ b/zflow_graph/src/types.rs
@@ -81,7 +81,7 @@ pub struct GraphExportedPort {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct GraphTransaction {
-    pub id: Option<String>,
+    pub id: String,
     pub depth: i32,
 }
 


### PR DESCRIPTION
To make checking if starting and ending transaction a little cleaner, instead of checking if self.transaction.id is None, the whole object could as well be optional. then when creating GraphTransaction, the id must always be set